### PR TITLE
[CBP-35482] Replace all references from platform to Unify

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ This action supports many popular testing tools, and enables testing results fro
 
 == Prerequisites
 
-Set up CloudBees Unify and GHA to work together, providing key features of the platform to GHA workflows.
+Set up CloudBees Unify and GHA to work together, providing key features of Unify to GHA workflows.
 Refer to link:https://docs.cloudbees.com/docs/cloudbees-platform/latest/github-actions/gha-getting-started[Getting started with GHA integration] for more information.
 
 == Inputs
@@ -142,7 +142,7 @@ jobs:
       - name: Push binary
         run: echo "Pushing binary to ECR..."
 
-      - name: Register Build Artifacts in Cloudbees Platform
+      - name: Register Build Artifacts in CloudBees Unify
         uses: cloudbees-io-gha/register-build-artifact@v3
         id: go-action
         with:
@@ -163,7 +163,7 @@ jobs:
       - name: Checkout to collect test results
         uses: actions/checkout@v3
 
-      - name: Publish test results in Cloudbees platform
+      - name: Publish test results in CloudBees Unify
         uses: cloudbees-io-gha/publish-test-results@v2
         with:
           test-type: GO


### PR DESCRIPTION
This PR updates all remaining references from 'platform' to 'Unify' to ensure consistent terminology across documentation.